### PR TITLE
fix stack elements width inconsistency by removing extra div

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -390,7 +390,7 @@
 						class="basis-1/4 flex flex-col items-center justify-center border-2 border-background-dark p-2 text-[1.5rem] hover-tonbo-dark"
 						href="https://github.com/tonbo-io/tonbo/tree/main/bindings"
 					>
-						Js/Py Bindings
+						JS/Py Bindings
 						<p class="text-left w-full">-></p>
 					</a>
 				</div>
@@ -435,7 +435,6 @@
 							epoll-based and io_uring-based runtimes.
 						</p>
 					</a>
-					<div class="flex-1"></div>
 				</div>
 			</div>
 			<div


### PR DESCRIPTION
Before:
<img width="1228" alt="image" src="https://github.com/user-attachments/assets/28bd48a4-ef38-4743-9731-85379b467632" />

After:
<img width="1238" alt="image" src="https://github.com/user-attachments/assets/243ddac0-6ec2-4f04-8100-8160b9c52fc1" />
